### PR TITLE
feat: Add semantic versioning support for Terraform downloader

### DIFF
--- a/terraform-client/pom.xml
+++ b/terraform-client/pom.xml
@@ -157,13 +157,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
@@ -184,6 +177,12 @@
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.semver4j</groupId>
+            <artifactId>semver4j</artifactId>
+            <version>6.0.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
- Introduce semver4j for parsing and validating Terraform version ranges.
- Improve logic to select the appropriate Terraform version based on range matching.
- Update dependencies to include semver4j and clean up unused imports in `pom.xml`.